### PR TITLE
Updating typo in example config file

### DIFF
--- a/config_examples/config.json
+++ b/config_examples/config.json
@@ -17,7 +17,7 @@
             "protocol": "https",
             "method": "POST",
             "headers": {
-                "ContenType": "application/xml",
+                "ContentType": "application/xml",
                 "header1": "header2"
             },
             "payload": "Body content 1",


### PR DESCRIPTION
There was a typo in the example config file. It should be "Content Type" instead of "conten Type"